### PR TITLE
Fix the pending_tickets queue

### DIFF
--- a/route/bitfinity/src/evm_scan.rs
+++ b/route/bitfinity/src/evm_scan.rs
@@ -168,7 +168,7 @@ pub async fn handle_runes_mint(
     event: RunesMintRequested,
 ) -> anyhow::Result<()> {
     let ticket = ticket_from_runes_mint_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| BitfinityRouteError::HubError(s))?;
     log!(INFO,
@@ -180,7 +180,7 @@ pub async fn handle_runes_mint(
 
 pub async fn handle_token_burn(log_entry: &TransactionReceiptLog, event: TokenBurned) -> anyhow::Result<()> {
     let ticket = ticket_from_burn_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| BitfinityRouteError::HubError(s))?;
     log!(INFO, "[bitfinity route] burn_ticket sent to hub success: {:?}", ticket);
@@ -192,7 +192,7 @@ pub async fn handle_token_transport(
     event: TokenTransportRequested,
 ) -> anyhow::Result<()> {
     let ticket = ticket_from_transport_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| BitfinityRouteError::HubError(s))?;
     log!(INFO,

--- a/route/bitfinity/src/service.rs
+++ b/route/bitfinity/src/service.rs
@@ -292,7 +292,7 @@ pub async fn rewrite_tx_hash(ticket_id: String, tx_hash: String) {
 #[update(guard = "is_admin")]
 pub async fn resend_ticket_to_hub(tx_hash: String) {
     let (ticket, _tr) = create_ticket_by_tx(&tx_hash).await.unwrap();
-    let _: () = ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    let _: () = ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| BitfinityRouteError::HubError(s))
         .unwrap();

--- a/route/evm/src/evm_scan.rs
+++ b/route/evm/src/evm_scan.rs
@@ -196,7 +196,7 @@ pub async fn handle_runes_mint(
     event: RunesMintRequested,
 ) -> anyhow::Result<()> {
     let ticket = Ticket::from_runes_mint_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| Error::HubError(s))?;
     log!(INFO,
@@ -208,7 +208,7 @@ pub async fn handle_runes_mint(
 
 pub async fn handle_token_burn(log_entry: &LogEntry, event: TokenBurned) -> anyhow::Result<()> {
     let ticket = Ticket::from_burn_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| Error::HubError(s))?;
     log!(INFO, "[evm_route] burn_ticket sent to hub success: {:?}", ticket);
@@ -220,7 +220,7 @@ pub async fn handle_token_transport(
     event: TokenTransportRequested,
 ) -> anyhow::Result<()> {
     let ticket = Ticket::from_transport_event(log_entry, event);
-    ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| Error::HubError(s))?;
     log!(INFO,

--- a/route/evm/src/service.rs
+++ b/route/evm/src/service.rs
@@ -318,7 +318,7 @@ pub async fn rewrite_tx_hash(ticket_id: String, tx_hash: String) {
 #[update(guard = "is_admin")]
 pub async fn resend_ticket_to_hub(tx_hash: String) {
     let (ticket, _tr) = create_ticket_by_tx(&tx_hash).await.unwrap();
-    let _r: () = ic_cdk::call(crate::state::hub_addr(), "send_ticket", (ticket.clone(),))
+    let _r: () = ic_cdk::call(crate::state::hub_addr(), "finalize_ticket", (ticket.clone(),))
         .await
         .map_err(|(_, s)| Error::HubError(s))
         .unwrap();


### PR DESCRIPTION
Issue: The pending_tickets queue in the hub has been continuously accumulating.

Cause: While other canisters use send_ticket to send tickets to the hub, the Bitcoin custom, Bitcoinbrc20 custom, Bitfinity, and EVM canisters use hub::pending_ticket to send tickets to the queue. However, Bitfinity and EVM do not use hub::finalize_ticket to remove tickets from the queue, resulting in an increasing queue length.

Solution: Replace send_ticket with finalize_ticket in the same functions, ensuring that pending tickets are removed immediately afterward.

@StewartYe please review this pr as I'm having hard time to test it locally.
